### PR TITLE
#45 [update] fixed styles for the like and watchlist buttons

### DIFF
--- a/components/pages/SearchResults.vue
+++ b/components/pages/SearchResults.vue
@@ -90,10 +90,10 @@ export default {
 .like_button
   position: absolute
   bottom: 2%
-  right: 24%
+  right: 65px
 
 .watch_button
   position: absolute
   bottom: 2%
-  right: 3%
+  right: 8px
 </style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -27,4 +27,8 @@ export default {
 <style lang="sass">
 img
   max-width: 100%
+
+@media only screen and (min-width: 1024px) and (max-height: 1366px) and (orientation: portrait) and (-webkit-min-device-pixel-ratio: 1.5)
+  .container
+    max-width: 100%
 </style>


### PR DESCRIPTION
- changed unit for right from % to px for consistency
- added a new media query that targets iPad Pro, and it makes the container width 100% (the container on iPad Pro was too narrow)